### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: true
       matrix:
         include: [
-#          { msystem: MINGW64, project: 'mingw-gcc', bindir: 'win64_mingw-gcc' },
-          { msystem: CLANG64, project: 'mingw-clang', bindir: 'win64_mingw-clang' },
+          { msystem: MINGW64, project: 'mingw-gcc', bindir: 'win64_mingw-gcc' },
+#         { msystem: CLANG64, project: 'mingw-clang', bindir: 'win64_mingw-clang' },
         ]
     name: mingw-${{ matrix.msystem }}
     runs-on: windows-latest
@@ -29,6 +29,8 @@ jobs:
         with:
           repository: bkaradzic/bx
           path: bx
+          fetch-depth: 0
+      - run: cd bx && git checkout 198cd12 || cd ..
       - name: Checkout bimg
         uses: actions/checkout@v4
         with:
@@ -45,12 +47,12 @@ jobs:
         shell: msys2 {0}
         run: |
           cd bgfx
-          make ${{ matrix.project }}-release64 -j$(nproc) AR=ar CC=cc CXX=c++ MINGW=$MINGW_PREFIX
+          make shaderc -j$(nproc) AR=ar CC=cc CXX=c++ MINGW=$MINGW_PREFIX
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
-        with: 
+        with:
           name: shaderc-win-x64.exe
-          path: ./bgfx/.buildk/${{ matrix.bindir }}/bin/shadercRelease.exe
+          path: ./bgfx/.build/${{ matrix.bindir }}/bin/shadercRelease.exe
   linux:
     strategy:
       fail-fast: true
@@ -70,6 +72,8 @@ jobs:
         with:
           repository: bkaradzic/bx
           path: bx
+          fetch-depth: 0
+      - run: cd bx && git checkout 198cd12 || cd ..
       - name: Checkout bimg
         uses: actions/checkout@v4
         with:
@@ -79,10 +83,10 @@ jobs:
         run: |
           sudo apt install libgl-dev
           cd bgfx
-          make -j$(nproc) linux-${{ matrix.config }}64
+          make -j$(nproc) shaderc
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
-        with: 
+        with:
           name: shaderc-linux-x64
           path: ./bgfx/.build/linux64_gcc/bin/shaderc${{ matrix.binsuffix }}
   osx:
@@ -104,6 +108,8 @@ jobs:
         with:
           repository: bkaradzic/bx
           path: bx
+          fetch-depth: 0
+      - run: cd bx && git checkout 198cd12 || cd ..
       - name: Checkout bimg
         uses: actions/checkout@v4
         with:
@@ -112,10 +118,10 @@ jobs:
       - name: Build
         run: |
           cd bgfx
-          make -j$(sysctl -n hw.physicalcpu) osx-x64-${{ matrix.config }}
+          make -j$(sysctl -n hw.physicalcpu) shaderc
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
-        with: 
+        with:
           name: shaderc-osx-x64
           path: ./bgfx/.build/osx-x64/bin/shaderc${{ matrix.binsuffix }}
   android:
@@ -132,7 +138,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r25b
+          ndk-version: r25c
           add-to-path: false
       - name: Checkout bgfx
         uses: actions/checkout@v4
@@ -143,6 +149,8 @@ jobs:
         with:
           repository: bkaradzic/bx
           path: bx
+          fetch-depth: 0
+      - run: cd bx && git checkout 198cd12 || cd ..
       - name: Checkout bimg
         uses: actions/checkout@v4
         with:
@@ -150,8 +158,12 @@ jobs:
           path: bimg
       - name: Build
         run: |
+          sudo apt install libgl-dev
+          ar -cr $ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libpthread.a
+          ar -cr $ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi/libpthread.a
           cd bgfx
-          make -j$(sysctl -n hw.physicalcpu) android-${{ matrix.platform }}
+          make .build/projects/gmake-android-${{ matrix.platform }}
+          make -j$(nproc) -R -C .build/projects/gmake-android-${{ matrix.platform }} shaderc config=release
         env:
           ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
       - name: Check
@@ -160,6 +172,6 @@ jobs:
           ls -lash ".build/android-${{ matrix.platform }}/bin"
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
-        with: 
-          name: shaderc-linux-${{ matrix.platform }}
-          path: ./bgfx/.build/android-${{ matrix.platform }}/bin/shadercRelease
+        with:
+          name: shaderc-android-${{ matrix.platform }}
+          path: ./bgfx/.build/android-${{ matrix.platform }}/bin/libshadercRelease

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,71 +9,28 @@ on:
   pull_request:
 
 jobs:
-  msvc:
-    strategy:
-      fail-fast: true
-      matrix:
-        include: [
-          { config: Debug, platform: Win32, bindir: 'win32_vs2019' },
-          { config: Debug, platform: x64, bindir: 'win64_vs2019' },
-          { config: Release, platform: Win32, bindir: 'win32_vs2019' },
-          { config: Release, platform: x64, bindir: 'win64_vs2019' },
-        ]
-    name: msvc-${{ matrix.config }}-${{ matrix.platform }}
-    runs-on: windows-2019
-    steps:
-      - name: Checkout bgfx
-        uses: actions/checkout@v3
-        with:
-          path: bgfx
-      - name: Checkout bx
-        uses: actions/checkout@v3
-        with:
-          repository: bkaradzic/bx
-          path: bx
-      - name: Checkout bimg
-        uses: actions/checkout@v3
-        with:
-          repository: bkaradzic/bimg
-          path: bimg
-      - name: Prepare
-        uses: microsoft/setup-msbuild@v1.1
-      - name: Build
-        shell: cmd
-        run: |
-          cd bgfx
-          ..\bx\tools\bin\windows\genie.exe --with-tools --with-combined-examples --with-shared-lib vs2019
-          msbuild ".build/projects/vs2019/bgfx.sln" /m /v:minimal /p:Configuration=${{ matrix.config }} /p:Platform=${{ matrix.platform }}
-      - name: Check
-        shell: cmd
-        run: |
-          cd bgfx
-          dir /s ".build\${{ matrix.bindir }}\bin"
-          ".build\${{ matrix.bindir }}\bin\geometryc${{ matrix.config }}.exe" --version
-          ".build\${{ matrix.bindir }}\bin\shaderc${{ matrix.config }}.exe" --version
-          ".build\${{ matrix.bindir }}\bin\texturec${{ matrix.config }}.exe" --version
   mingw:
     strategy:
       fail-fast: true
       matrix:
         include: [
-          { msystem: MINGW64, project: 'mingw-gcc', bindir: 'win64_mingw-gcc' },
+#          { msystem: MINGW64, project: 'mingw-gcc', bindir: 'win64_mingw-gcc' },
           { msystem: CLANG64, project: 'mingw-clang', bindir: 'win64_mingw-clang' },
         ]
     name: mingw-${{ matrix.msystem }}
     runs-on: windows-latest
     steps:
       - name: Checkout bgfx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: bgfx
       - name: Checkout bx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: bkaradzic/bx
           path: bx
       - name: Checkout bimg
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: bkaradzic/bimg
           path: bimg
@@ -89,36 +46,32 @@ jobs:
         run: |
           cd bgfx
           make ${{ matrix.project }}-release64 -j$(nproc) AR=ar CC=cc CXX=c++ MINGW=$MINGW_PREFIX
-      - name: Check
-        shell: cmd
-        run: |
-          cd bgfx
-          dir /s ".build\${{ matrix.bindir }}\bin"
-          ".build\${{ matrix.bindir }}\bin\geometrycRelease.exe" --version
-          ".build\${{ matrix.bindir }}\bin\shadercRelease.exe" --version
-          ".build\${{ matrix.bindir }}\bin\texturecRelease.exe" --version
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with: 
+          name: shaderc-win-x64.exe
+          path: ./bgfx/.buildk/${{ matrix.bindir }}/bin/shadercRelease.exe
   linux:
     strategy:
       fail-fast: true
       matrix:
         include: [
-          { config: debug, binsuffix: Debug },
           { config: release, binsuffix: Release },
         ]
     name: linux-${{ matrix.config }}64
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout bgfx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: bgfx
       - name: Checkout bx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: bkaradzic/bx
           path: bx
       - name: Checkout bimg
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: bkaradzic/bimg
           path: bimg
@@ -127,71 +80,32 @@ jobs:
           sudo apt install libgl-dev
           cd bgfx
           make -j$(nproc) linux-${{ matrix.config }}64
-      - name: Check
-        run: |
-          cd bgfx
-          ls -lash ".build/linux64_gcc/bin"
-          ".build/linux64_gcc/bin/geometryc${{ matrix.binsuffix}}" --version
-          ".build/linux64_gcc/bin/shaderc${{ matrix.binsuffix}}" --version
-          ".build/linux64_gcc/bin/texturec${{ matrix.binsuffix}}" --version
-  wasm:
-    strategy:
-      fail-fast: true
-      matrix:
-        config: [ debug, release]
-    name: wasm-${{ matrix.config }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout bgfx
-        uses: actions/checkout@v3
-        with:
-          path: bgfx
-      - name: Checkout bx
-        uses: actions/checkout@v3
-        with:
-          repository: bkaradzic/bx
-          path: bx
-      - name: Checkout bimg
-        uses: actions/checkout@v3
-        with:
-          repository: bkaradzic/bimg
-          path: bimg
-      - name: Prepare
-        run: |
-          docker pull emscripten/emsdk
-          docker run --rm emscripten/emsdk which emcc em++ emar
-          cd bgfx
-          EMSCRIPTEN=/emsdk/upstream/emscripten ../bx/tools/bin/linux/genie --with-examples --gcc=wasm gmake
-      - name: Build
-        run: >
-          docker run --rm -u $(id -u):$(id -g) -v $(pwd):/bgfx emscripten/emsdk
-          make -C /bgfx/bgfx wasm-${{ matrix.config }} -j$(nproc) EMSCRIPTEN=/emsdk/upstream/emscripten
-      - name: Check
-        run: |
-          cd bgfx
-          ls -lash ".build/wasm/bin"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with: 
+          name: shaderc-linux-x64
+          path: ./bgfx/.build/linux64_gcc/bin/shaderc${{ matrix.binsuffix }}
   osx:
     strategy:
       fail-fast: true
       matrix:
         include: [
-          { config: debug, binsuffix: Debug },
           { config: release, binsuffix: Release },
         ]
     name: osx-x64-${{ matrix.config }}
     runs-on: macos-latest
     steps:
       - name: Checkout bgfx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: bgfx
       - name: Checkout bx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: bkaradzic/bx
           path: bx
       - name: Checkout bimg
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: bkaradzic/bimg
           path: bimg
@@ -199,19 +113,18 @@ jobs:
         run: |
           cd bgfx
           make -j$(sysctl -n hw.physicalcpu) osx-x64-${{ matrix.config }}
-      - name: Check
-        run: |
-          cd bgfx
-          ls -lash ".build/osx-x64/bin"
-          ".build/osx-x64/bin/geometryc${{ matrix.binsuffix}}" --version
-          ".build/osx-x64/bin/shaderc${{ matrix.binsuffix}}" --version
-          ".build/osx-x64/bin/texturec${{ matrix.binsuffix}}" --version
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with: 
+          name: shaderc-osx-x64
+          path: ./bgfx/.build/osx-x64/bin/shaderc${{ matrix.binsuffix }}
   android:
     strategy:
       fail-fast: true
       matrix:
         include: [
-          { platform: arm64  },
+          { platform: arm },
+          { platform: arm64 },
         ]
     name: android-${{ matrix.platform }}
     runs-on: ubuntu-22.04
@@ -222,16 +135,16 @@ jobs:
           ndk-version: r25b
           add-to-path: false
       - name: Checkout bgfx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: bgfx
       - name: Checkout bx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: bkaradzic/bx
           path: bx
       - name: Checkout bimg
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: bkaradzic/bimg
           path: bimg
@@ -245,3 +158,8 @@ jobs:
         run: |
           cd bgfx
           ls -lash ".build/android-${{ matrix.platform }}/bin"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with: 
+          name: shaderc-linux-${{ matrix.platform }}
+          path: ./bgfx/.build/android-${{ matrix.platform }}/bin/shadercRelease

--- a/makefile
+++ b/makefile
@@ -65,7 +65,7 @@ idl: ## Generate code from IDL.
 	cd scripts && ../$(GENIE) idl
 
 .build/projects/gmake-android-arm:
-	$(GENIE) --gcc=android-arm --with-combined-examples --with-shared-lib gmake
+	$(GENIE) --gcc=android-arm --with-tools --with-combined-examples --with-shared-lib gmake
 android-arm-debug: .build/projects/gmake-android-arm ## Build - Android ARM Debug
 	$(MAKE) -R -C .build/projects/gmake-android-arm config=debug
 android-arm-release: .build/projects/gmake-android-arm ## Build - Android ARM Release
@@ -73,7 +73,7 @@ android-arm-release: .build/projects/gmake-android-arm ## Build - Android ARM Re
 android-arm: android-arm-debug android-arm-release ## Build - Android ARM Debug and Release
 
 .build/projects/gmake-android-arm64:
-	$(GENIE) --gcc=android-arm64 --with-combined-examples --with-shared-lib gmake
+	$(GENIE) --gcc=android-arm64 --with-tools --with-combined-examples --with-shared-lib gmake
 android-arm64-debug: .build/projects/gmake-android-arm64 ## Build - Android ARM64 Debug
 	$(MAKE) -R -C .build/projects/gmake-android-arm64 config=debug
 android-arm64-release: .build/projects/gmake-android-arm64 ## Build - Android ARM64 Release


### PR DESCRIPTION
This PR updates the workflow to build only shaderc (release) and upload binary artifacts for:
- win x64, android arm, android arm64, osx x64, linux x64

The workflow currently uses an old commit of bx (198cd12). With the latest commit of bx, there seem to be some errors when building shaderc.