### PR TITLE
Improvements and fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,14 +48,13 @@ jobs:
         run: |
           cd bgfx
           make shaderc -j$(nproc) AR=ar CC=cc CXX=c++ MINGW=$MINGW_PREFIX
-      - run: cd ./bgfx/.build/${{ matrix.bindir }}/bin/
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: shaderc-win-x64.exe
-          path: shadercRelease.exe
+          path: ./bgfx/.build/${{ matrix.bindir }}/bin/shadercRelease.exe
       - name: Zip binary
-        run: zip shaderc-win-x64.zip shadercRelease.exe
+        run: zip -j shaderc-win-x64.zip ./bgfx/.build/${{ matrix.bindir }}/bin/shadercRelease.exe
       - name: Publish binary
         uses: softprops/action-gh-release@v2
         with:
@@ -93,14 +92,13 @@ jobs:
           sudo apt install libgl-dev
           cd bgfx
           make -j$(nproc) shaderc
-      - run: cd ./bgfx/.build/linux64_gcc/bin/
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: shaderc-linux-x64
-          path: shaderc${{ matrix.binsuffix }}
+          path: ./bgfx/.build/linux64_gcc/bin/shaderc${{ matrix.binsuffix }}
       - name: Zip binary
-        run: zip shaderc-linux-x64.zip shaderc${{ matrix.binsuffix }}
+        run: zip -j shaderc-linux-x64.zip ./bgfx/.build/linux64_gcc/bin/shaderc${{ matrix.binsuffix }}
       - name: Publish binary
         uses: softprops/action-gh-release@v2
         with:
@@ -137,14 +135,13 @@ jobs:
         run: |
           cd bgfx
           make -j$(sysctl -n hw.physicalcpu) shaderc
-      - run: cd ./bgfx/.build/osx-x64/bin/
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: shaderc-osx-x64
-          path: shaderc${{ matrix.binsuffix }}
+          path: ./bgfx/.build/osx-x64/bin/shaderc${{ matrix.binsuffix }}
       - name: Zip binary
-        run: zip shaderc-osx-x64.zip shaderc${{ matrix.binsuffix }}
+        run: zip -j shaderc-osx-x64.zip ./bgfx/.build/osx-x64/bin/shaderc${{ matrix.binsuffix }}
       - name: Publish binary
         uses: softprops/action-gh-release@v2
         with:
@@ -197,14 +194,13 @@ jobs:
         run: |
           cd bgfx
           ls -lash ".build/android-${{ matrix.platform }}/bin"
-      - run: cd ./bgfx/.build/android-${{ matrix.platform }}/bin/
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: shaderc-android-${{ matrix.platform }}
-          path: libshadercRelease
+          path: ./bgfx/.build/android-${{ matrix.platform }}/bin/libshadercRelease
       - name: Zip binary
-        run: zip shaderc-android-${{ matrix.platform }}.zip libshadercRelease
+        run: zip -j shaderc-android-${{ matrix.platform }}.zip ./bgfx/.build/android-${{ matrix.platform }}/bin/libshadercRelease
       - name: Publish binary
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           name: shaderc-win-x64.exe
           path: ./bgfx/.build/${{ matrix.bindir }}/bin/shadercRelease.exe
       - name: Zip binary
-        run: zip -j shaderc-win-x64.zip ./bgfx/.build/${{ matrix.bindir }}/bin/shadercRelease.exe
+        run: Compress-Archive -Path ./bgfx/.build/${{ matrix.bindir }}/bin/shadercRelease.exe -Destination shaderc-win-x64.zip
       - name: Publish binary
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,11 +48,20 @@ jobs:
         run: |
           cd bgfx
           make shaderc -j$(nproc) AR=ar CC=cc CXX=c++ MINGW=$MINGW_PREFIX
+      - run: cd ./bgfx/.build/${{ matrix.bindir }}/bin/
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: shaderc-win-x64.exe
-          path: ./bgfx/.build/${{ matrix.bindir }}/bin/shadercRelease.exe
+          path: shadercRelease.exe
+      - name: Zip binary
+        run: zip shaderc-win-x64.zip shadercRelease.exe
+      - name: Publish binary
+        uses: softprops/action-gh-release@v2
+        with:
+          files: shaderc-win-x64.zip
+          tag_name: binaries
+          fail_on_unmatched_files: true
   linux:
     strategy:
       fail-fast: true
@@ -84,11 +93,20 @@ jobs:
           sudo apt install libgl-dev
           cd bgfx
           make -j$(nproc) shaderc
+      - run: cd ./bgfx/.build/linux64_gcc/bin/
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: shaderc-linux-x64
-          path: ./bgfx/.build/linux64_gcc/bin/shaderc${{ matrix.binsuffix }}
+          path: shaderc${{ matrix.binsuffix }}
+      - name: Zip binary
+        run: zip shaderc-linux-x64.zip shaderc${{ matrix.binsuffix }}
+      - name: Publish binary
+        uses: softprops/action-gh-release@v2
+        with:
+          files: shaderc-linux-x64.zip
+          tag_name: binaries
+          fail_on_unmatched_files: true
   osx:
     strategy:
       fail-fast: true
@@ -119,11 +137,20 @@ jobs:
         run: |
           cd bgfx
           make -j$(sysctl -n hw.physicalcpu) shaderc
+      - run: cd ./bgfx/.build/osx-x64/bin/
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: shaderc-osx-x64
-          path: ./bgfx/.build/osx-x64/bin/shaderc${{ matrix.binsuffix }}
+          path: shaderc${{ matrix.binsuffix }}
+      - name: Zip binary
+        run: zip shaderc-osx-x64.zip shaderc${{ matrix.binsuffix }}
+      - name: Publish binary
+        uses: softprops/action-gh-release@v2
+        with:
+          files: shaderc-osx-x64.zip
+          tag_name: binaries
+          fail_on_unmatched_files: true
   android:
     strategy:
       fail-fast: true
@@ -170,8 +197,17 @@ jobs:
         run: |
           cd bgfx
           ls -lash ".build/android-${{ matrix.platform }}/bin"
+      - run: cd ./bgfx/.build/android-${{ matrix.platform }}/bin/
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: shaderc-android-${{ matrix.platform }}
-          path: ./bgfx/.build/android-${{ matrix.platform }}/bin/libshadercRelease
+          path: libshadercRelease
+      - name: Zip binary
+        run: zip shaderc-android-${{ matrix.platform }}.zip libshadercRelease
+      - name: Publish binary
+        uses: softprops/action-gh-release@v2
+        with:
+          files: shaderc-android-${{ matrix.platform }}.zip
+          tag_name: binaries
+          fail_on_unmatched_files: true

--- a/src/bgfx_compute.sh
+++ b/src/bgfx_compute.sh
@@ -57,8 +57,14 @@
 		_type _name[];                                          \
 	}
 
+#define __BUFFER(_name, _type, _reg)                \
+	layout(std430, binding=_reg) buffer _name ## Buffer \
+	{                                                           \
+		_type _name[];                                          \
+	}
+
 #define BUFFER_RO(_name, _type, _reg) __BUFFER_XX(_name, _type, _reg, readonly)
-#define BUFFER_RW(_name, _type, _reg) __BUFFER_XX(_name, _type, _reg, readwrite)
+#define BUFFER_RW(_name, _type, _reg) __BUFFER(_name, _type, _reg)
 #define BUFFER_WR(_name, _type, _reg) __BUFFER_XX(_name, _type, _reg, writeonly)
 
 #define NUM_THREADS(_x, _y, _z) layout (local_size_x = _x, local_size_y = _y, local_size_z = _z) in;
@@ -139,15 +145,9 @@
 
 #define UIMAGE3D_RW(_name, _format, _reg) IMAGE3D_RW(_name, _format, _reg)
 
-#if BGFX_SHADER_LANGUAGE_METAL || BGFX_SHADER_LANGUAGE_SPIRV
 #define BUFFER_RO(_name, _struct, _reg) StructuredBuffer<_struct>   _name : REGISTER(t, _reg)
 #define BUFFER_RW(_name, _struct, _reg) RWStructuredBuffer <_struct> _name : REGISTER(u, _reg)
 #define BUFFER_WR(_name, _struct, _reg) BUFFER_RW(_name, _struct, _reg)
-#else
-#define BUFFER_RO(_name, _struct, _reg) Buffer<_struct>   _name : REGISTER(t, _reg)
-#define BUFFER_RW(_name, _struct, _reg) RWBuffer<_struct> _name : REGISTER(u, _reg)
-#define BUFFER_WR(_name, _struct, _reg) BUFFER_RW(_name, _struct, _reg)
-#endif
 
 #define NUM_THREADS(_x, _y, _z) [numthreads(_x, _y, _z)]
 
@@ -290,6 +290,31 @@ __IMAGE_IMPL_ATOMIC(uint,       x,    uvec4, xxxx)
 #define groupMemoryBarrier()         GroupMemoryBarrierWithGroupSync()
 
 #endif // BGFX_SHADER_LANGUAGE_GLSL
+
+#define IMAGE2D_RO_AUTOREG( _name, _format) IMAGE2D_RO(_name, _format, _name ## _REG)
+#define UIMAGE2D_RO_AUTOREG(_name, _format) UIMAGE2D_RO(_name, _format, _name ## _REG)
+#define IMAGE2D_WR_AUTOREG( _name, _format) IMAGE2D_WR(_name, _format, _name ## _REG)
+#define UIMAGE2D_WR_AUTOREG(_name, _format) UIMAGE2D_WR(_name, _format, _name ## _REG)
+#define IMAGE2D_RW_AUTOREG( _name, _format) IMAGE2D_RW(_name, _format, _name ## _REG)
+#define UIMAGE2D_RW_AUTOREG(_name, _format) UIMAGE2D_RW(_name, _format, _name ## _REG)
+
+#define IMAGE2D_ARRAY_RO_AUTOREG( _name, _format) IMAGE2D_ARRAY_RO(_name, _format, _name ## _REG)
+#define UIMAGE2D_ARRAY_RO_AUTOREG(_name, _format) UIMAGE2D_ARRAY_RO(_name, _format, _name ## _REG)
+#define IMAGE2D_ARRAY_WR_AUTOREG( _name, _format) IMAGE2D_ARRAY_WR(_name, _format, _name ## _REG)
+#define UIMAGE2D_ARRAY_WR_AUTOREG(_name, _format) UIMAGE2D_ARRAY_WR(_name, _format, _name ## _REG)
+#define IMAGE2D_ARRAY_RW_AUTOREG( _name, _format) IMAGE2D_ARRAY_RW(_name, _format, _name ## _REG)
+#define UIMAGE2D_ARRAY_RW_AUTOREG(_name, _format) UIMAGE2D_ARRAY_RW(_name, _format, _name ## _REG)
+
+#define IMAGE3D_RO_AUTOREG( _name, _format) IMAGE3D_RO(_name, _format, _name ## _REG)
+#define UIMAGE3D_RO_AUTOREG(_name, _format) UIMAGE3D_RO(_name, _format, _name ## _REG)
+#define IMAGE3D_WR_AUTOREG( _name, _format) IMAGE3D_WR(_name, _format, _name ## _REG)
+#define UIMAGE3D_WR_AUTOREG(_name, _format) UIMAGE3D_WR(_name, _format, _name ## _REG)
+#define IMAGE3D_RW_AUTOREG( _name, _format) IMAGE3D_RW(_name, _format, _name ## _REG)
+#define UIMAGE3D_RW_AUTOREG(_name, _format) UIMAGE3D_RW(_name, _format, _name ## _REG)
+
+#define BUFFER_RO_AUTOREG(_name, _type) BUFFER_RO(_name, _type, _name ## _REG)
+#define BUFFER_RW_AUTOREG(_name, _type) BUFFER_RW(_name, _type, _name ## _REG)
+#define BUFFER_WR_AUTOREG(_name, _type) BUFFER_WR(_name, _type, _name ## _REG)
 
 #define dispatchIndirect( \
 	  _buffer             \

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -241,6 +241,19 @@ namespace bgfx
 		NULL
 	};
 
+	static const char* s_EXT_texture_cube_map_array[] =
+	{
+
+		"iimageCubeArray",
+		"imageCubeArray",
+		"isamplerCubeArray",
+		"samplerCubeArray",
+		"samplerCubeArrayShadow",
+		"uimageCubeArray",
+		"usamplerCubeArray",
+		NULL
+	};
+
 	static const char* s_ARB_texture_multisample[] =
 	{
 		"sampler2DMS",
@@ -2224,13 +2237,14 @@ namespace bgfx
 									&& !bx::findIdentifierMatch(input, s_ARB_gpu_shader5).isEmpty()
 									;
 
-								const bool usesInstanceID         = !bx::findIdentifierMatch(input, "gl_InstanceID").isEmpty();
-								const bool usesGpuShader4         = !bx::findIdentifierMatch(input, s_EXT_gpu_shader4).isEmpty();
-								const bool usesTexelFetch         = !bx::findIdentifierMatch(input, s_texelFetch).isEmpty();
-								const bool usesTextureMS          = !bx::findIdentifierMatch(input, s_ARB_texture_multisample).isEmpty();
-								const bool usesTextureArray       = !bx::findIdentifierMatch(input, s_textureArray).isEmpty();
-								const bool usesPacking            = !bx::findIdentifierMatch(input, s_ARB_shading_language_packing).isEmpty();
-								const bool usesViewportLayerArray = !bx::findIdentifierMatch(input, s_ARB_shader_viewport_layer_array).isEmpty();
+								const bool usesInstanceID          = !bx::findIdentifierMatch(input, "gl_InstanceID").isEmpty();
+								const bool usesGpuShader4          = !bx::findIdentifierMatch(input, s_EXT_gpu_shader4).isEmpty();
+								const bool usesTexelFetch          = !bx::findIdentifierMatch(input, s_texelFetch).isEmpty();
+								const bool usesTextureMS           = !bx::findIdentifierMatch(input, s_ARB_texture_multisample).isEmpty();
+								const bool usesTextureArray        = !bx::findIdentifierMatch(input, s_textureArray).isEmpty();
+								const bool usesCubemapTextureArray = !bx::findIdentifierMatch(input, s_EXT_texture_cube_map_array).isEmpty();
+								const bool usesPacking             = !bx::findIdentifierMatch(input, s_ARB_shading_language_packing).isEmpty();
+								const bool usesViewportLayerArray  = !bx::findIdentifierMatch(input, s_ARB_shader_viewport_layer_array).isEmpty();
 								const bool usesUnsignedVecs        = !bx::findIdentifierMatch(preprocessedInput, s_unsignedVecs).isEmpty();
 
 								if (profile->lang != ShadingLang::ESSL)
@@ -2464,6 +2478,13 @@ namespace bgfx
 										bx::stringPrintf(code
 											, "#extension GL_EXT_texture_array : enable\n"
 											);
+									}
+
+									if (usesCubemapTextureArray)
+									{
+										bx::stringPrintf(code
+											, "#extension GL_EXT_texture_cube_map_array : enable\n"
+										);
 									}
 
 									if (glsl_profile > 100 && 'f' == _options.shaderType)

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -278,10 +278,13 @@ namespace bgfx
 		NULL
 	};
 
-	static const char* s_unsignedVecs[] =
+	static const char* s_integerVecs[] =
 	{
+		"ivec2",
 		"uvec2",
+		"ivec3",
 		"uvec3",
+		"ivec4",
 		"uvec4",
 		NULL
 	};
@@ -2245,7 +2248,7 @@ namespace bgfx
 								const bool usesCubemapTextureArray = !bx::findIdentifierMatch(input, s_EXT_texture_cube_map_array).isEmpty();
 								const bool usesPacking             = !bx::findIdentifierMatch(input, s_ARB_shading_language_packing).isEmpty();
 								const bool usesViewportLayerArray  = !bx::findIdentifierMatch(input, s_ARB_shader_viewport_layer_array).isEmpty();
-								const bool usesUnsignedVecs        = !bx::findIdentifierMatch(preprocessedInput, s_unsignedVecs).isEmpty();
+								const bool usesIntegerVecs         = !bx::findIdentifierMatch(preprocessedInput, s_integerVecs).isEmpty();
 
 								if (profile->lang != ShadingLang::ESSL)
 								{
@@ -2253,11 +2256,11 @@ namespace bgfx
 										|| !bx::findIdentifierMatch(input, s_130).isEmpty()
 										|| usesInterpolationQualifiers
 										|| usesTexelFetch
-										|| usesUnsignedVecs
+										|| usesIntegerVecs
 										) );
 
-									bx::stringPrintf(code, "#version %d\n", need130 ? 130 : glsl_profile);
-									glsl_profile = 130;
+									glsl_profile = need130 ? 130 : glsl_profile;
+									bx::stringPrintf(code, "#version %d\n", glsl_profile);
 
 									if (need130)
 									{
@@ -2336,15 +2339,6 @@ namespace bgfx
 											);
 									}
 
-									if (130 > glsl_profile)
-									{
-										bx::stringPrintf(code,
-											"#define ivec2 vec2\n"
-											"#define ivec3 vec3\n"
-											"#define ivec4 vec4\n"
-											);
-									}
-
 									if (ARB_shader_texture_lod)
 									{
 										bx::stringPrintf(code,
@@ -2381,7 +2375,7 @@ namespace bgfx
 								}
 								else
 								{
-									if ((glsl_profile < 300) && usesUnsignedVecs)
+									if ((glsl_profile < 300) && usesIntegerVecs)
 									{
 										glsl_profile = 300;
 									}

--- a/tools/shaderc/shaderc_glsl.cpp
+++ b/tools/shaderc/shaderc_glsl.cpp
@@ -227,6 +227,23 @@ namespace bgfx { namespace glsl
 					parse = bx::strLTrimSpace(bx::strFindNl(bx::StringView(eol.getPtr(), parse.getTerm() ) ) );
 				}
 			}
+
+			// Insert #version directive.
+			{
+				std::string versionString = "#version " + std::to_string(_version);
+				const std::string esEnding = "_es";
+				
+				if (
+					_version > 100 && _options.profile.size() >= esEnding.size() &&
+        			_options.profile.compare(_options.profile.size() - esEnding.size(), esEnding.size(), esEnding) == 0
+					) 
+				{
+					versionString.append(" es");
+				}
+				versionString.append("\n");
+				out.insert(0, versionString);
+				optimizedShader = out.c_str();
+			}
 		}
 		else
 		{

--- a/tools/shaderc/shaderc_metal.cpp
+++ b/tools/shaderc/shaderc_metal.cpp
@@ -222,7 +222,9 @@ namespace bgfx { namespace metal
 		"BgfxISampler3D",
 		"BgfxUSampler3D",
 		"BgfxSamplerCube",
+		"BgfxSamplerCubeArray",
 		"BgfxSamplerCubeShadow",
+		"BgfxSamplerCubeArrayShadow"
 		"BgfxSampler2DMS",
 	};
 

--- a/tools/shaderc/shaderc_spirv.cpp
+++ b/tools/shaderc/shaderc_spirv.cpp
@@ -328,7 +328,9 @@ namespace bgfx { namespace spirv
 		"BgfxISampler3D",
 		"BgfxUSampler3D",
 		"BgfxSamplerCube",
+		"BgfxSamplerCubeArray",
 		"BgfxSamplerCubeShadow",
+		"BgfxSamplerCubeArrayShadow"
 		"BgfxSampler2DMS",
 	};
 


### PR DESCRIPTION
With those changes, shaderc binaries will now be published not only as artifacts but also as assets in release, with `binaries` tag. Distributing binaries only through artifacts has a few disadvantages such as requiring a github account to download and the fact that artifacts expire after 3 months.